### PR TITLE
add identity function

### DIFF
--- a/corefn/misc/misc.go
+++ b/corefn/misc/misc.go
@@ -166,3 +166,19 @@ var SafeRead = interpreter.TaFunction{
 		return blockToRun, nil
 	},
 }
+
+var Identity = interpreter.TaFunction{
+	CommonSignature: interpreter.CommonSignature{
+		Name: "identity",
+		Arguments: []token.Kind{token.Any},
+		Returns:     token.Any,
+		Description: "Returns its argument",
+		Example: `
+(identity 1)                                                     ; returns 1
+(identity true)                                                  ; returns true
+`,
+	},
+	Func: func(interp *interpreter.Interpreter, args ...*token.TaToken) (*token.TaToken, error) {
+		return args[0], nil
+	},
+}

--- a/corefn/misc/misc_allop.go
+++ b/corefn/misc/misc_allop.go
@@ -11,5 +11,6 @@ func AllOperations() []interpreter.TaFunction {
 		Do,
 		DoLegacy,
 		SafeRead,
+		Identity,
 	}
 }

--- a/corefn/misc/misc_test.go
+++ b/corefn/misc/misc_test.go
@@ -182,3 +182,11 @@ func TestSafeRead(t *testing.T) {
 		// }
 	)
 }
+
+func TestIdentity(t *testing.T) {
+	helpers.RunTests(t, helpers.Test{
+		"identity 1",
+		nil,
+        token.NewDecimalFromInt(1),
+	})
+}

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -365,6 +365,13 @@ Extract the hour (00-23) from a time
 (hour 2018-01-14T19:04:05Z)                                      ; returns "19"
 ```
 
+### identity(Any)Any
+Returns its argument
+```lisp
+(identity 1)                                                     ; returns 1
+(identity true)                                                  ; returns true
+```
+
 ### isEmpty(List)Boolean
 Check if a list is empty
 ```lisp


### PR DESCRIPTION
In some cases, we want to pass scalar values to the rule engine. 
E.g. when we want to use some placeholders in a statement and the value for placeholder has to be a valid talang statement, so know it should look like `(+ 0 42)` or `(and true true)` or even like this `(split "" "")`.
The identity function allows making it more straightforward. 